### PR TITLE
feat: 카테고리 구현(#17)

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as SelectPrimitive from '@radix-ui/react-select'
-import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+import { Check, ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 const Select = SelectPrimitive.Root
@@ -9,23 +9,34 @@ const SelectValue = SelectPrimitive.Value
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+    disabledBg?: boolean
+  }
+>(({ className, children, disabledBg, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'focus:ring-primary-DEFAULT flex h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 text-sm ring-offset-white placeholder:text-gray-500 focus:ring-2 focus:outline-none',
+      'flex h-[48px] w-full items-center justify-between rounded-[4px] border px-[16px] py-[10px] text-sm focus:outline-none',
+      'border-[#9D9D9D]',
+      disabledBg
+        ? 'cursor-not-allowed bg-[#ECECEC] text-[#BDBDBD]'
+        : 'cursor-pointer bg-[#FAFAFA] text-[#121212]',
       className
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown
+        className={cn(
+          disabledBg ? 'text-[#BDBDBD]' : 'text-[#121212]',
+          'h-4 w-4'
+        )}
+      />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+SelectTrigger.displayName = 'SelectTrigger'
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
@@ -34,27 +45,21 @@ const SelectContent = React.forwardRef<
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
-      className={cn(
-        'z-50 mt-1 min-w-[8rem] overflow-hidden rounded-md border bg-white shadow-md',
-        className
-      )}
+      position="popper"
+      side="bottom"
+      align="start"
+      sideOffset={4}
+      className={cn('z-50 rounded-md border bg-white shadow-md', className)}
+      style={{ width: 'var(--radix-select-trigger-width)' }}
       {...props}
     >
-      <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
-        <ChevronUp className="h-3 w-3" />
-      </SelectPrimitive.ScrollUpButton>
-
       <SelectPrimitive.Viewport className="p-1">
         {children}
       </SelectPrimitive.Viewport>
-
-      <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1">
-        <ChevronDown className="h-3 w-3" />
-      </SelectPrimitive.ScrollDownButton>
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
 ))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+SelectContent.displayName = 'SelectContent'
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
@@ -63,21 +68,20 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-pointer items-center rounded-sm py-2 pr-2 pl-8 text-sm outline-none select-none hover:bg-gray-100 focus:bg-gray-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-pointer items-center justify-between rounded-sm px-3 py-2 text-sm outline-none select-none',
+      'hover:bg-[#EFE6FC] focus:bg-[#EFE6FC]',
+      'data-[state=checked]:bg-[#FAFAFA] data-[state=checked]:text-[#6201E0]',
       className
     )}
     {...props}
   >
-    <span className="absolute left-2 flex items-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check className="text-primary-DEFAULT h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemIndicator>
+      <Check className="h-4 w-4 text-[#6201E0]" />
+    </SelectPrimitive.ItemIndicator>
   </SelectPrimitive.Item>
 ))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+SelectItem.displayName = 'SelectItem'
 
 export {
   Select,

--- a/src/data/Category.ts
+++ b/src/data/Category.ts
@@ -1,0 +1,103 @@
+interface CategoryMap {
+  [key: string]: string[]
+}
+
+interface CategoryData {
+  [key: string]: CategoryMap
+}
+
+export const CATEGORY_DATA: CategoryData = {
+  프론트엔드: {
+    '프로그래밍 언어': [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+    웹프레임워크: [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+    Web: [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+    OS: [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+    라이브러리: [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+  },
+  백엔드: {
+    '프로그래밍 언어': [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+    웹프레임워크: [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+    Web: [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+    OS: [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+    라이브러리: [
+      'JavaScript',
+      'Python',
+      'Django',
+      'React',
+      'Next.js',
+      'FastAPI',
+      'Nginx',
+    ],
+  },
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,1 @@
+export * from './Category'

--- a/src/pages/CreatePage/QuestionCreate.tsx
+++ b/src/pages/CreatePage/QuestionCreate.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-
 import Button from '@/components/common/Button'
 import Card from '@/components/common/Card'
 import { Input } from '@/components/ui/input'
@@ -11,111 +10,7 @@ import {
   SelectContent,
   SelectItem,
 } from '@/components/ui/select'
-
-interface CategoryMap {
-  [key: string]: string[]
-}
-
-interface CategoryData {
-  [key: string]: CategoryMap
-}
-
-const CATEGORY_DATA: CategoryData = {
-  프론트엔드: {
-    '프로그래밍 언어': [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-    웹프레임워크: [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-    Web: [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-    OS: [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-    라이브러리: [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-  },
-  백엔드: {
-    '프로그래밍 언어': [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-    웹프레임워크: [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-    Web: [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-    OS: [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-    라이브러리: [
-      'JavaScript',
-      'Python',
-      'Django',
-      'React',
-      'Next.js',
-      'FastAPI',
-      'Nginx',
-    ],
-  },
-}
+import { CATEGORY_DATA } from '@/data/Category'
 
 const QuestionCreate = () => {
   const [mainCategory, setMainCategory] = useState<string>()
@@ -125,7 +20,6 @@ const QuestionCreate = () => {
   const middleOptions = mainCategory
     ? Object.keys(CATEGORY_DATA[mainCategory])
     : []
-
   const subOptions =
     mainCategory && middleCategory
       ? CATEGORY_DATA[mainCategory][middleCategory]
@@ -136,7 +30,6 @@ const QuestionCreate = () => {
       <h1 className="mb-2 w-full max-w-[944px] text-2xl font-bold">
         질문 작성하기
       </h1>
-
       <div className="mb-6 h-[1px] w-full max-w-[944px] bg-[#CECECE]" />
 
       <Card className="flex w-full max-w-[944px] flex-col gap-4 rounded-[20px] border px-[38px] py-10">
@@ -150,10 +43,9 @@ const QuestionCreate = () => {
               setSubCategory(undefined)
             }}
           >
-            <SelectTrigger className="h-[48px] flex-1 rounded-[4px] border border-[#9D9D9D] px-[16px] py-[10px] text-sm">
+            <SelectTrigger>
               <SelectValue placeholder="대분류 선택" />
             </SelectTrigger>
-
             <SelectContent>
               {Object.keys(CATEGORY_DATA).map((item) => (
                 <SelectItem key={item} value={item}>
@@ -173,10 +65,9 @@ const QuestionCreate = () => {
             }}
             disabled={!mainCategory}
           >
-            <SelectTrigger className="h-[48px] flex-1 rounded-[4px] border border-[#9D9D9D] px-[16px] py-[10px] text-sm">
+            <SelectTrigger disabledBg={!mainCategory}>
               <SelectValue placeholder="중분류 선택" />
             </SelectTrigger>
-
             <SelectContent>
               {middleOptions.map((item) => (
                 <SelectItem key={item} value={item}>
@@ -193,10 +84,9 @@ const QuestionCreate = () => {
             onValueChange={setSubCategory}
             disabled={!middleCategory}
           >
-            <SelectTrigger className="h-[48px] flex-1 rounded-[4px] border border-[#9D9D9D] px-[16px] py-[10px] text-sm">
+            <SelectTrigger disabledBg={!middleCategory}>
               <SelectValue placeholder="소분류 선택" />
             </SelectTrigger>
-
             <SelectContent>
               {subOptions.map((item) => (
                 <SelectItem key={item} value={item}>


### PR DESCRIPTION
## PR 요약

- 연관된 이슈:#17

- 작업 요약:
  - 카테고리 기능 select 이용하여 구현
  - select 공통 컴포넌트 디자인 커스텀 마이징
  - 카테고리 데이터 분리 및 재사용 구조 정리


## 상세 내용(기능 요약)

> 무엇을(What?):
- 질문 작성 페이지에서 대분류 → 중분류 → 소분류로 이어지는 카테고리 선택 UI를 구현.
- 카테고리 데이터(CATEGORY_DATA)를 별도 파일로 분리.
- select 컴포넌트를 프로젝트 디자인에 맞게 커스터마이징 함.

> 왜(Why?):
- 질문 작성 시 카테고리를 단계적으로 선택할 수 있도록 하여 사용자 입력 오류를 줄이고 UX를 개선하기 위함.
- 카테고리 데이터와 UI 로직을 분리해 이후 백엔드 API 연동 시 구조 변경을 최소화하기 위함.
- 공통 Select UI를 커스터마이징해 프로젝트 전반에서 일관된 스타일을 유지하려는 목적.

> 어떻게/의도와 방향(How?):
- 카테고리 데이터는 대분류 → 중분류 → 소분류(string[]) 구조로 정의해 API 응답 구조로 쉽게 대체 가능하도록 구성함.
- 상위 카테고리가 변경될 경우 하위 카테고리 상태를 초기화하여 잘못된 조합이 선택되지 않도록 처리함.

> 시도,고민할 점(Optional):
- 카테고리 타입을 union이나 enum으로 제한할지 고민했으나, 현재는 API 스펙이 확정되지 않은 상태라 유연성을 우선해 string 타입으로 유지함.
- 추후 API 연동 시 타입을 좁히거나 공통 타입으로 분리할 수 있도록 구조를 열어둠.

> 리뷰 받고 싶은 포인트:
- 카테고리 상태 관리 방식이 적절한지
- select 컴포넌트 커스터마이징 구조가 과하지 않은지
- 추후 API 연동을 고려했을 때 개선할 부분이 있는지

## 스크린 샷
> 
<img width="1728" height="1117" alt="스크린샷 2025-12-17 오전 10 56 51" src="https://github.com/user-attachments/assets/7d4e3998-3e32-4512-b3c6-8552072203e5" />

<img width="1728" height="1117" alt="스크린샷 2025-12-17 오전 10 57 14" src="https://github.com/user-attachments/assets/354b6d5d-5a83-4e1d-be0d-89c156c9793b" />
(대분류, 중분류, 소분류 선택 후 다시 대분류를 재선택했을때 초기화 됨)

## 기타 참고사항

> 현재 카테고리 데이터는 목업 데이터이며 API 연동 시 교체될 예정

## PR 체크리스트

- [x] 커밋 메세지 컨벤션에 맞게 작성했습니다.
- [x] 변경사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
