### PR TITLE
feat: 질의응답 상세페이지 ui구현 (#13)

### DIFF
--- a/src/components/common/Card2.tsx
+++ b/src/components/common/Card2.tsx
@@ -4,7 +4,7 @@ import { Button, Card, Textarea } from '../ui'
 
 export default function JaeminCard() {
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
+    <div className="px-4 py-8">
       <Card className="my-8">
         <div className="border-gray-200 p-2"></div>
 

--- a/src/components/common/Item/Item.tsx
+++ b/src/components/common/Item/Item.tsx
@@ -1,0 +1,17 @@
+import { Avatar } from '@radix-ui/react-avatar'
+export default function JaeminCard() {
+  return (
+    <div className="flex space-x-3 border-gray-50 py-4">
+      <Avatar className="h-10 w-10 shrink-0 rounded-full bg-purple-200" />
+
+      <div className="flex flex-col">
+        <div className="flex items-center gap-2">
+          <span className="font-bold text-gray-900">iron</span>
+          <span className="text-sm text-gray-400">2025년 6월 13일</span>
+        </div>
+
+        <div className="mt-1.5 text-[15px] text-gray-800">감사합니다!</div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/Item/Item1.tsx
+++ b/src/components/common/Item/Item1.tsx
@@ -1,0 +1,19 @@
+import { Avatar } from '@radix-ui/react-avatar'
+export default function JaeminCard() {
+  return (
+    <div className="flex space-x-3 border-gray-50 py-4">
+      <Avatar className="h-10 w-10 shrink-0 rounded-full bg-purple-200" />
+
+      <div className="flex flex-col">
+        <div className="flex items-center gap-2">
+          <span className="font-bold text-gray-900">name2</span>
+          <span className="text-sm text-gray-400">2025년 6월 13일</span>
+        </div>
+
+        <div className="mt-1.5 text-[15px] text-gray-800">
+          도움 많이 되었습니다. 감사합니다!
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/Item/Item2.tsx
+++ b/src/components/common/Item/Item2.tsx
@@ -1,0 +1,17 @@
+import { Avatar } from '@radix-ui/react-avatar'
+export default function JaeminCard() {
+  return (
+    <div className="flex space-x-3 border-gray-50 py-4">
+      <Avatar className="h-10 w-10 shrink-0 rounded-full bg-purple-200" />
+
+      <div className="flex flex-col">
+        <div className="flex items-center gap-2">
+          <span className="font-bold text-gray-900">코딩잘하고싶다아</span>
+          <span className="text-sm text-gray-400">2025년 6월 13일</span>
+        </div>
+
+        <div className="mt-1.5 text-[15px] text-gray-800">좋네요!</div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/Item/Item3.tsx
+++ b/src/components/common/Item/Item3.tsx
@@ -1,0 +1,19 @@
+import { Avatar } from '@radix-ui/react-avatar'
+export default function JaeminCard() {
+  return (
+    <div className="flex space-x-3 border-gray-50 py-4">
+      <Avatar className="h-10 w-10 shrink-0 rounded-full bg-purple-200" />
+
+      <div className="flex flex-col">
+        <div className="flex items-center gap-2">
+          <span className="font-bold text-gray-900">junbugo</span>
+          <span className="text-sm text-gray-400">2025년 6월 13일</span>
+        </div>
+
+        <div className="mt-1.5 text-[15px] text-gray-800">
+          오히려 깔끔한 것 같아요
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,11 +1,16 @@
-import { ChevronRight, Link2 } from 'lucide-react'
 import { Avatar, AvatarImage } from '@/components/ui/Avatar'
 import Button from '@/components/ui/Button'
+import { ArrowUpDown, ChevronRight, Link, MessageCircle } from 'lucide-react'
 import Card2 from '../components/common/Card2'
+import Textarea from '../components/common/Textarea'
+import Card from '../components/common/Card'
+import Item2 from '../components/common/Item/Item2'
+import Item1 from '../components/common/Item/Item1'
+import Item3 from '../components/common/Item/Item3'
 
 export default function QuestionDetail() {
   return (
-    <div className="mx-auto max-w-5xl px-4 py-8">
+    <div className="mx-auto max-w-4xl px-4 py-8">
       {/* 1. 상단 브레드크럼  */}
       <nav className="mb-4 flex items-center gap-1 text-sm font-bold text-purple-700">
         <span>프론트엔드</span>
@@ -25,6 +30,14 @@ export default function QuestionDetail() {
             print 를 5번 쓰지 않고, print 를 1번만 쓰고 5줄을 모두 표시하는 법이
             있나요?
           </h1>
+
+          <div className="flex items-center gap-2">
+            <Avatar className="h-10 w-10 bg-black"></Avatar>
+
+            <p className="font-medium whitespace-nowrap text-gray-700">
+              김태산
+            </p>
+          </div>
         </div>
 
         {/* 사용자 아바타 및 이름 */}
@@ -38,32 +51,119 @@ export default function QuestionDetail() {
       {/* 3. 조회수 및 수정 버튼 영역 */}
       <div className="mt-6 flex items-center justify-between text-sm">
         <p className="text-gray-400">조회수 60 · 15시간 전</p>
-        <button className="text-purple-700 transition-all hover:font-bold">
+        <button className="cursor-pointer text-purple-700 transition-all hover:font-bold">
           수정
         </button>
       </div>
 
       {/* 4. 본문 내용 영역 */}
-      <div className="mt-4 border-t border-gray-200 pt-10">
+      <div className="mt-4 border-y-1 border-gray-300 py-5 pt-10">
         <p className="text-[16px] leading-relaxed text-gray-800">
           print 명령어를 5번 안쓰고 print 한번만 쓰고 내용을 모두 넣고 표시하는
           법이 있나요?
         </p>
-      </div>
-
-      {/* 5. 하단 공유하기 버튼 영역*/}
-      <div className="mt-16 border-t border-gray-200 pt-6">
-        <div className="flex justify-end">
-          <Button
-            variant="outline"
-            className="flex items-center gap-2 rounded-full border-gray-300 px-6 py-5 text-gray-500 hover:bg-gray-50"
-          >
-            <Link2 className="h-4 w-4" />
-            <span className="font-medium">공유하기</span>
-          </Button>
-          <Card2></Card2>
+        <div className="mt-16 border-gray-200 pt-6">
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              className="flex cursor-pointer items-center gap-2 rounded-full border-gray-300 px-4 py-5 text-gray-500 hover:bg-gray-50"
+            >
+              <Link className="h-4 w-4" />
+              <span className="font-medium">공유하기</span>
+            </Button>
+          </div>
         </div>
       </div>
+
+      {/* 5. 몇개의 답변*/}
+      <div className="border-gray-200 p-10"></div>
+      <div className="flex items-center gap-2 py-6">
+        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-purple-600 font-bold text-white">
+          A
+        </div>
+        <p className="text-lg font-semibold text-gray-800">
+          <span>2개의 답변이 있어요</span>
+        </p>
+      </div>
+
+      <Card>
+        <div className="p-4">
+          <div className="p-4 py-3">
+            <div className="flex items-center">
+              <Avatar className="h-10 w-10 shrink-0 rounded-full bg-purple-200" />
+              <span className="px-3">
+                young2name
+                <div className="text-sm text-gray-400">
+                  IT스타트업 실무형 풀스택 웹 개발 부트캠프 · 채택된 답변 수 1
+                </div>
+              </span>
+              <Button className="text-nded-full ml-auto cursor-pointer rounded-full px-7 py-5 text-sm font-semibold text-white">
+                채택하기
+              </Button>
+            </div>
+            {/* 답변 내용 */}
+            <div>
+              <p className="py-4">이렇게 쓸 수 있을 것 같습니당.</p>
+              <div className="my-6 rounded-lg border-gray-700 bg-gray-200 p-8">
+                <pre className="font-mono text-sm leading-relaxed whitespace-pre-wrap text-gray-700">
+                  {`print("""1. 동해물과
+2. 백두산이
+3. 마르고 닳도록
+4. 하느님이 보우하사
+5. 우리 나라 만세
+""")
+
+# 결과
+# 1. 동해물과
+# 2. 백두산이
+# 3. 마르고 닳도록
+# 4. 하느님이 보우하사
+# 5. 우리 나라 만세`}
+                </pre>
+              </div>
+            </div>
+            {/* {댓글 등록} */}
+            <div className="text-right text-sm text-gray-400">
+              11 시간 전
+              <div className="">
+                <div className="relative">
+                  <Textarea
+                    className="h-20 w-full border border-gray-300 p-3 pr-19 text-sm"
+                    placeholder="  개인정보를 공유 및 요청하거나, 비방, 불법 정보 유포 등의 행위는 제재될 수 있습니다."
+                  ></Textarea>
+                  <Button className="absolute right-3 bottom-3 cursor-pointer rounded-full bg-gray-300 px-5 py-2 text-sm text-black">
+                    등록
+                  </Button>
+                </div>
+              </div>
+            </div>
+            <div className="p-0">
+              {/* 댓글 헤더 영역 */}
+              <div className="flex items-center justify-between border-b border-gray-200 py-4">
+                <div className="flex items-center">
+                  <MessageCircle
+                    className="h-6 w-6 text-black"
+                    strokeWidth={2.5}
+                  />
+
+                  <h2 className="pl-1 font-semibold">댓글 1개 </h2>
+                </div>
+                <button className="flex items-center text-sm text-gray-600">
+                  최신순
+                  <ArrowUpDown className="h-4 w-4" />
+                </button>
+              </div>
+
+              {/* {댓글 내용} */}
+              <Item3 />
+              <Item1 />
+              <Item2 />
+              <div className="ml-3 min-w-0 flex-1"></div>
+            </div>
+          </div>
+        </div>
+      </Card>
+      <Card2></Card2>
     </div>
   )
 }


### PR DESCRIPTION
## PR 요약

- 연관된 이슈: #13 

- 작업 요약:
  
       - 페이지 들어갈때 나오는 페이지ui
       - 답변, 공유, 채택, 수정 할때 나오는 ui 구현

## 상세 내용(기능 요약)

> 무엇을(What?): 

 - 상세페이지 레이아웃 구조화: 카드 컴포넌트 내부에 Textarea, Button 등을 배치하고 div 박스로 영역을 명확히 구분했습니다.
 - 질문/답변 UI 구현: 질문 제목, 작성자 아바타 정보, 답변 개수 표시 등 상세페이지 핵심 UI를 완성했습니다.
 - Git 충돌 해결: dev 브랜치 병합 과정에서 발생한 DetailPage.tsx 파일 충돌을 수동으로 해결하고 코드를 통합했습니다.

> 왜(Why?): 

- 사용자가 질문 상세 내용을 확인하고, 바로 답변을 달거나 채택/수정 기능을 원활하게 이용할 수 있는 기반을 마련하기 위함입니다.

- 팀원 간의 UI 컨벤션을 맞추어 추후 기능 연동 시 코드 파편화를 방지하기 위함입니다.

> 어떻게/의도와 방향(How?):

- 제목이 길어질 경우를 대비해 shrink-0 및 whitespace-nowrap 등을 활용하여 아바타 영역이 찌그러지지 않도록 설계했습니다.

- 컴포넌트 재사용: 공통 컴포넌트인 Avatar, Button 등을 활용하여 프로젝트 전반의 일관성을 유지했습니다.

> 시도,고민할 점(Optional):

- 하면서 div태그가 어떻게 해야 깔끔하게 정리가 되는지 멘토님 혹은 팀원분들과 소통하면서 정리했습니다

> 리뷰 받고 싶은 포인트:
- 다시한번  div정렬이 잘 되어있는지 부탁드립니다.
- 이런저런 테일윈드 쓰다보니 쓸때없는 테일윈드가 들어가 있는지 부탁드립니다 
## 스크린 샷

>
<img width="305" height="700" alt="스크린샷 2025-12-19 오후 5 27 01" src="https://github.com/user-attachments/assets/2906f8cb-3f6f-4c98-becf-b13e987f2b0f" />


## 기타 참고사항

>

## PR 체크리스트

- [x] 커밋 메세지 컨벤션에 맞게 작성했습니다.
- [x] 변경사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
